### PR TITLE
CSS: Fix incomplete `width`

### DIFF
--- a/static/css/style.less
+++ b/static/css/style.less
@@ -229,10 +229,6 @@ section#posts {
 		/*}*/
 	}
 
-	p {
-		width: 600px;
-	}
-
 	blockquote {
 		margin: 0;
 		padding: 0 0 0 20px;
@@ -352,12 +348,12 @@ section#posts {
 	article {
 		margin: 0;
 		padding: 40px 40px 40px 50px;
-		min-width: 620px;
 		position: relative;
 		font-size: 15px;
 		line-height: 25px;
 		overflow-x: hidden;
 		overflow-y: hidden;
+		width: 620px;
 
 		#title{
 			font-family: 'Freight-Sans-Pro', 'Proxima Nova', 'Open Sans', 'Lato', sans-serif;


### PR DESCRIPTION
While `width` was set on paragraphs (`<p>`), they were not set on other
tags in an article. This lead to `<ul>` tags and others tags not
wrapping correctly.

![screen shot 2013-06-20 at 00 24 13](https://f.cloud.github.com/assets/730342/678218/caba46ac-d92e-11e2-9fdb-3441ca7e4ed4.png)
