### PR TITLE
CSS: Add `margin-right` to `.bio`

### DIFF
--- a/static/css/style.less
+++ b/static/css/style.less
@@ -123,7 +123,7 @@ section#sidebar {
 	}
 
 	p.bio {
-		padding: 0 0 0 40px;
+		padding: 0 20px 0 40px;
 	}
 
 	ul {


### PR DESCRIPTION
Otherwise the bio will be touching the grey line to it's right, which is
not aesthetically pleasing.

Before:
![screen shot 2013-06-20 at 00 38 14](https://f.cloud.github.com/assets/730342/678295/dfe5a222-d930-11e2-91dd-0f53dbb7dcc3.png)

After:
![screen shot 2013-06-20 at 00 37 24](https://f.cloud.github.com/assets/730342/678297/eb61a36c-d930-11e2-9de2-35433f01130d.png)
