### PR TITLE
CSS: Making list item spacing smaller

### DIFF
--- a/static/css/style.less
+++ b/static/css/style.less
@@ -216,7 +216,7 @@ section#posts {
 		list-style-position: outside;
 
 		li {
-			margin: 0 0 15px 15px;
+			margin: 0 0 0 15px;
 			padding: 3px 0 3px 5px;
 		}
 


### PR DESCRIPTION
The spacing was too much to be aesthetically pleasing as it did not
follow the `line-height` proportions. This commit fixes this.

Before:
![screen shot 2013-06-20 at 00 53 29](https://f.cloud.github.com/assets/730342/678368/ed15bbf6-d932-11e2-9259-ab827bb575f7.png)

After:
![screen shot 2013-06-20 at 00 50 42](https://f.cloud.github.com/assets/730342/678369/f0d63392-d932-11e2-836a-75fb2b01fd07.png)
